### PR TITLE
Add use_raw_path option to ratelimit dependency

### DIFF
--- a/ratelimit/__init__.py
+++ b/ratelimit/__init__.py
@@ -81,11 +81,13 @@ def ratelimit(
     *ranks: tuple[LimitRule, ...] | LimitRule,
     no_block_delay: bool = True,
     no_hit_on_exceptions: tuple[type[Exception], ...] = None,
+    use_raw_path: bool = False,
 ):
     """
     Ratelimit dependency
     :param ranks: Limit ranks
     :param no_block_delay: No block at rules with "delay" set
+    :param use_raw_path: Use endpoint raw path
     :return: Actual dependency
     """
 
@@ -112,6 +114,11 @@ def ratelimit(
             user = context_user
 
         path = request.url.path
+        if use_raw_path:
+            path = (
+                request.scope.get("root_path")
+                + request.scope.get("route").path_format
+            )
         method = request.method
 
         log.debug(


### PR DESCRIPTION
Add option to use path_format to determine endpoint usage by user.

By default endpoint `/user/{username}` with path parameter `username` set to `"bob"` will be treated as `/user/bob`. But with option `use_raw_path` set to `True` it will be treated by path set to route definition - `/user/{username}`. This allows to ratelimit user that requests endpoint regardless of the parameters set to path.